### PR TITLE
Add conditional fit using xr.where and test

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -39,7 +39,8 @@ New Features
 * Directional distribution module with the following options:
   * Cartwright (1986) cosine-square distribution.
   * Bunney (2014) skewed distribution for turning wind sea.
-* Methods for fitting Jonswap and Gaussian from the spectra in SpecArray by `pbranson`_ (`PR <https://github.com/oceanum/wavespectra/pull/3>`_).
+* Methods for fitting Jonswap and Gaussian from the spectra in SpecArray by `pbranson`_ (`PR <https://github.com/oceanum/wavespectra/pull/4>`_).
+* Method for non-linear gaussian fit in SpecArray by `pbranson`_ (`PR <https://github.com/oceanum/wavespectra/pull/3>`_).
 * Gaussian frequency width method `gw` in SpecArray.
 * Jonswap peak enhancement factor method `gamma` in SpecArray.
 * Jonswap fetch scaling coefficient method `alpha` in SpecArray.

--- a/tests/fit/test_conditional.py
+++ b/tests/fit/test_conditional.py
@@ -1,0 +1,32 @@
+"""Testing Gaussian fitting."""
+import os
+import numpy as np
+import pytest
+
+from wavespectra import read_swan
+from wavespectra.fit.conditional import fit_conditional
+from wavespectra.fit.jonswap import fit_jonswap
+from wavespectra.fit.gaussian import fit_gaussian
+
+
+FILES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../sample_files")
+
+
+@pytest.fixture(scope="module")
+def freq():
+    filename = os.path.join(FILES_DIR, "swanfile.spec")
+    _dset = read_swan(filename).interp({"freq": np.arange(0.04, 0.4, 0.001)})
+    yield _dset.freq
+
+
+def test_conditional(freq):
+    """Test Hs, Tp values are conserved."""
+    cond = True
+    kwargs = dict(freq=freq, hs=2, fp=1 / 10, gamma=3.3, gw=0.07, cond=cond)
+    ds_true = fit_jonswap(**kwargs)
+    ds_false = fit_gaussian(**kwargs)
+    ds = fit_conditional(**kwargs)
+    assert ds.equals(ds_true)
+    kwargs['cond']=False
+    ds = fit_conditional(**kwargs)
+    assert ds.equals(ds_false)

--- a/wavespectra/fit/conditional.py
+++ b/wavespectra/fit/conditional.py
@@ -1,0 +1,49 @@
+"""Conditional frequency spectrum selecting a given shape based on a boolean array."""
+import numpy as np
+import xarray as xr
+from scipy.constants import pi
+
+from wavespectra.core.utils import scaled, check_same_coordinates, to_coords, load_function
+from wavespectra.core.attributes import attrs
+
+
+def fit_conditional(freq, hs, fp, cond, when_true='fit_jonswap',when_false='fit_gaussian',**kwargs):
+    """Conditional frequency spectrum.
+
+    Args:
+        - freq (DataArray): Frequency array (Hz).
+        - hs (DataArray, float): Significant wave height (m).
+        - fp (DataArray, float): Peak wave frequency (Hz).
+        - cond (DataArray, bool): .
+        - when_true: spectral shape function when cond == True.
+        - when_false: spectral shape function when cond == False.
+        - kwargs: kwargs must have all arguments for both when_true and when_false functions.
+
+    Returns:
+        - efth (SpecArray): Conditional frequency spectrum E(f) (m2s).
+
+    Note:
+        - The spectra are scaled so that :math:`4\\sqrt{m_0} = hs`.
+        - If two or more input args other than `freq` are DataArrays,
+          they must share the same coordinates.
+
+    """
+    check_same_coordinates(hs, fp, cond)
+    if not isinstance(freq, xr.DataArray):
+        freq = to_coords(freq, "freq")
+
+    import inspect
+    arg_vals = inspect.getargvalues(inspect.currentframe())
+    arguments = {a:arg_vals.locals[a] for a in arg_vals.args}
+    arguments.update(arg_vals.locals['kwargs'])
+
+    true_func = load_function("wavespectra", when_true, prefix="fit_")
+    false_func = load_function("wavespectra", when_false, prefix="fit_")
+
+    ds_true = true_func(**arguments)
+    ds_false = false_func(**arguments)
+    dsout = xr.where(cond,ds_true,ds_false)
+
+    dsout.name = attrs.SPECNAME
+
+    return dsout


### PR DESCRIPTION
This PR allows for choosing between two different spectral shapes for an individual partition based on a boolean array 'cond' that has the same shape as hs and fp.